### PR TITLE
Add a Docker build for isoping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM buildpack-deps:stable as build
+
+ADD . /opt/isochronous
+WORKDIR /opt/isochronous
+RUN make clean; make
+
+FROM gcr.io/distroless/cc
+COPY --from=build /opt/isochronous/isoping /
+EXPOSE 4948/udp
+CMD ["/isoping"]

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ UNAME := $(shell uname -s)
 ifneq ($(UNAME),Darwin)
 LDFLAGS+=-lrt -lm
 else
-CXXFLAGS+=-I/usr/local/opt/openssl/include
+CXXFLAGS+=-I/usr/local/opt/openssl@1.1/include
+LDFLAGS+=-L/usr/local/opt/openssl@1.1/lib
 endif
 
 PROGS=udpstress isoping isostream

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,5 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/isoping', '.' ]
+images:
+- 'gcr.io/$PROJECT_ID/isoping'

--- a/isoping.h
+++ b/isoping.h
@@ -176,7 +176,7 @@ class Sessions {
                                  size_t secret_len);
 
   // Fields required for calculating and verifying cookies.
-  EVP_MD_CTX digest_context;
+  EVP_MD_CTX *digest_context;
   const EVP_MD *md;
   std::mt19937_64 rng;
   uint32_t cookie_epoch;


### PR DESCRIPTION
This makes it easier to run an isoping server in public clouds.

The build builds isoping, then copies it to a bare container based on Google's lightweight container images (GoogleContainerTools/distroless). The resulting image is about 19 MB and builds with no additional tooling; I think the simplicity makes it a net win over the dockerize-based build I hacked together last year.